### PR TITLE
feat(project-setup): cLI that displays formatted JSON data in a styled, localized table

### DIFF
--- a/mod-03-ciclo-de-viva/demo05-esmodules-internacionalization/database.json
+++ b/mod-03-ciclo-de-viva/demo05-esmodules-internacionalization/database.json
@@ -1,0 +1,9 @@
+[
+  {
+    "id": 1,
+    "vehicles": ["Motocicleta", "Carro", "Caminhão"],
+    "kmTraveled": 10000,
+    "from": "2009-01-01",
+    "to": "2020-11-26"
+  }
+]

--- a/mod-03-ciclo-de-viva/demo05-esmodules-internacionalization/package.json
+++ b/mod-03-ciclo-de-viva/demo05-esmodules-internacionalization/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "demo05-esmodules-internacionalization",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "dev": "npx nodemon --ignore database.json --exec node --experimental-json-modules src/index.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "chalk": "^4.1.2",
+    "chalk-table": "^1.0.2",
+    "draftlog": "^1.0.13"
+  },
+  "devDependencies": {
+    "nodemon": "^3.1.10"
+  }
+}

--- a/mod-03-ciclo-de-viva/demo05-esmodules-internacionalization/src/index.js
+++ b/mod-03-ciclo-de-viva/demo05-esmodules-internacionalization/src/index.js
@@ -1,0 +1,35 @@
+import DraftLog from "draftlog";
+import chalk from "chalk";
+import chalkTable from "chalk-table";
+import readline from "readline";
+
+import database from "./../database.json";
+import Person from "./person.js";
+
+DraftLog(console).addLineListener(process.stdin);
+const DEFAULT_LANG = "pt-BR";
+const options = {
+  leftPad: 2,
+  columns: [
+    { field: "id", name: chalk.cyan("ID") },
+    { field: "vehicles", name: chalk.magenta("Vehicles") },
+    { field: "kmTraveled", name: chalk.cyan("KM Traveled") },
+    { field: "from", name: chalk.cyan("From") },
+    { field: "to", name: chalk.cyan("To") },
+  ],
+};
+
+const table = chalkTable(
+  options,
+  database.map((item) => new Person(item).formatted(DEFAULT_LANG))
+);
+const print = console.draft(table);
+
+const terminal = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout,
+});
+
+terminal.question("Qual é o seu nome?", (msg) => {
+  console.log("msg", msg.toString());
+});

--- a/mod-03-ciclo-de-viva/demo05-esmodules-internacionalization/src/person.js
+++ b/mod-03-ciclo-de-viva/demo05-esmodules-internacionalization/src/person.js
@@ -1,0 +1,38 @@
+export default class Person {
+  constructor({ id, vehicles, kmTraveled, from, to }) {
+    this.id = id;
+    this.vehicles = vehicles;
+    this.kmTraveled = kmTraveled;
+    this.from = from;
+    this.to = to;
+  }
+
+  formatted(language) {
+    const mapDate = (date) => {
+      const [year, month, day] = date.split("-").map(Number);
+
+      return new Date(year, month - 1, day);
+    };
+    return {
+      id: Number(this.id),
+      vehicles: new Intl.ListFormat(language, {
+        style: "long",
+        type: "conjunction",
+      }).format(this.vehicles),
+      kmTraveled: new Intl.NumberFormat(language, {
+        style: "unit",
+        unit: "kilometer",
+      }).format(this.kmTraveled),
+      from: new Intl.DateTimeFormat(language, {
+        month: "long",
+        day: "2-digit",
+        year: "numeric",
+      }).format(mapDate(this.from)),
+      to: new Intl.DateTimeFormat(language, {
+        month: "long",
+        day: "2-digit",
+        year: "numeric",
+      }).format(mapDate(this.to)),
+    };
+  }
+}


### PR DESCRIPTION
This project is a Command-Line Interface (CLI) that reads data from a JSON file, formats the information based on the locale (pt-BR), and displays it in a styled table using libraries like chalk, chalk-table, and draftlog. It also enables basic user interaction through readline, capturing input and logging responses in the terminal. The initial setup focuses on clean structure, data formatting, and internationalization (i18n) support.

#21